### PR TITLE
🔧 ライセンス年の自動更新とGitエイリアスのリファクタリング

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -12,4 +12,4 @@
 [difftool "default-difftool"]
 	cmd = code --wait --diff $LOCAL $REMOTE
 [alias]
-	new-feature = "!f() { \\\n  TITLE=\"$1\"; \\\n  DATE=$(date +%Y%m%d); \\\n  git checkout main && \\\n  git fetch origin -p && \\\n  git reset --hard origin/main && \\\n  git checkout -b \"feature/${TITLE}-${DATE}\"; \\\n}; f"
+	new-feature-branch = "!f() { \\\n  TITLE=\"$1\"; \\\n  DATE=$(date +%Y%m%d); \\\n  git checkout main && \\\n  git fetch origin -p && \\\n  git reset --hard origin/main && \\\n  git checkout -b \"feature/${TITLE}-${DATE}\"; \\\n}; f"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -1,0 +1,54 @@
+---
+name: Update License Year
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *"  # 毎年1月1日に実行
+  workflow_dispatch:
+
+jobs:
+  commit-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Make changes (e.g., update LICENSE year)
+        run: |
+          current_year=$(date +"%Y")
+          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create a new branch
+        run: |
+          branch_name="feature/update-license-year-$(date +'%Y%m%d-%H%M%S')"
+          git checkout -b "$branch_name"
+
+      - name: Commit changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add LICENSE
+            git commit -m "Update License year to $current_year"
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Push changes to new branch
+        run: |
+          git push -u origin "$branch_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "$branch_name"
+          base: "main"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Takeru O'oyama
+Copyright (c) 2023 Takeru O'oyama
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION

## 📓 変更点の概要

- `LICENSE`ファイルの著作権年を2023年に更新しました。
- GitHub Actionsを使用して、毎年1月1日に`LICENSE`ファイルの年を自動更新するワークフローを追加しました。
- `.gitconfig`ファイル内のGitエイリアス`new-feature`を`new-feature-branch`にリネームしました。

## ⚒ 技術的な詳細や注意点

- 📅 **ライセンス年の自動更新**: 新しいGitHub Actionsワークフロー`update-license-year.yml`が追加され、毎年1月1日に`LICENSE`ファイルの年を自動的に更新します。このワークフローは、変更があれば新しいブランチを作成し、プルリクエストを自動生成します。
  
- 🛠 **Gitエイリアスのリファクタリング**: `.gitconfig`ファイル内の`new-feature`エイリアスが`new-feature-branch`にリネームされました。これにより、エイリアスの命名がより明確になり、機能をより正確に表現しています。

> [!NOTE]
>
> - この変更により、`LICENSE`ファイルの年を手動で更新する必要がなくなります。
> - Gitエイリアスの名前が変更されたため、以前のエイリアスを使用していたスクリプトやドキュメントがある場合は、更新が必要です。