### PR TITLE
🔄 GitHubワークフローのリファクタリング: ライセンス年更新プロセスの改善

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -40,12 +40,6 @@ jobs:
             echo "No changes to commit"
           fi
 
-      - name: Push changes to new branch
-        run: |
-          git push -u origin "$branch_name"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION

## 📓 変更点の概要

- GitHubワークフローのリファクタリングを行い、ライセンス年の更新プロセスを簡素化しました。具体的には、変更を新しいブランチにプッシュするステップを削除し、直接プルリクエストを作成するようにしました。

## ⚒ 技術的な詳細や注意点

- 🛠️ `update-license-year.yml` から「変更を新しいブランチにプッシュする」ステップを削除しました。これにより、ワークフローが簡素化され、プルリクエストの作成が直接行われるようになりました。
- 🔧 `peter-evans/create-pull-request@v7` アクションを使用して、変更が自動的にプルリクエストとして提出されるように設定されています。これにより、手動でのブランチ管理が不要になり、プロセスが効率化されます。