### PR TITLE
🔄 GitHubワークフローのリファクタリング: ライセンス年更新の新しいブランチへのプッシュを追加

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Create a new branch
         run: |
           branch_name="feature/update-license-year-$(date +'%Y%m%d-%H%M%S')"
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 
       - name: Commit changes
@@ -39,6 +40,12 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+      - name: Push changes to new branch
+        run: |
+          git push -u origin "$branch_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION

## 📓 変更点の概要

- GitHubワークフローをリファクタリングし、ライセンス年を更新する際に変更を新しいブランチにプッシュするステップを追加しました。

## ⚒ 技術的な詳細や注意点

- 🛠 新しいブランチの作成時に、ブランチ名を環境変数 `GITHUB_ENV` に保存するようにしました。これにより、後続のステップでブランチ名を簡単に参照できます。
- 🚀 変更を新しいブランチにプッシュするステップを追加しました。このステップでは、GitHubのシークレット `GITHUB_TOKEN` を使用して認証を行います。
- 🔄 これにより、ライセンス年の更新が自動化され、手動でのプッシュ作業が不要になります。