### PR TITLE
🔄 GitHubワークフローのリファクタリング: ライセンス年の更新と新しいブランチへの変更プッシュ

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Make changes (e.g., update LICENSE year)
         run: |
           current_year=$(date +"%Y")
+          echo "current_year=$current_year" >> $GITHUB_ENV
           sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Configure Git
@@ -29,7 +30,6 @@ jobs:
       - name: Create a new branch
         run: |
           branch_name="feature/update-license-year-$(date +'%Y%m%d-%H%M%S')"
-          echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 
       - name: Commit changes
@@ -51,5 +51,5 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "${{ env.branch_name }}"
+          branch: $branch_name
           base: "main"


### PR DESCRIPTION

## 📓 変更点の概要

- GitHubワークフローをリファクタリングし、ライセンスファイルの年を更新し、新しいブランチに変更をプッシュするプロセスを改善しました。

## ⚒ 技術的な詳細や注意点

- 🛠 環境変数の設定方法を変更しました。`current_year`を`$GITHUB_ENV`にエコーすることで、他のステップで利用可能にしました。
- 🗑 不要な環境変数の設定を削除しました。`branch_name`を`$GITHUB_ENV`にエコーする行を削除し、直接変数を使用するようにしました。
- 🔄 `peter-evans/create-pull-request`アクションでのブランチ指定を、環境変数を使わずに直接変数を使用する形に変更しました。これにより、コードがよりシンプルで理解しやすくなりました。