### PR TITLE
## 🔄 GitHubワークフローのリファクタリング: ライセンス年更新のブランチ制限を解除

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Push changes to new branch
         run: |
-          git push -u origin "$branch_name"
+          git push -fu origin "$branch_name"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -19,6 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GHA_APP_ID }}
+          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Make changes (e.g., update LICENSE year)
         run: |
           current_year=$(date +"%Y")
@@ -53,7 +61,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           gh auth setup-git
           gh pr create --title "Update License year to $current_year" --body "This PR updates the license year to $current_year." --head "$branch_name" --base "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - "feature/refactor-update-license-workflow-5-20241027"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   commit-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -51,5 +51,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+<<<<<<< Updated upstream
           branch: $branch_name
+=======
+          branch: "${{ env.branch_name }}"
+>>>>>>> Stashed changes
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -58,5 +58,5 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: $branch_name
+          branch: ${{ env.branch_name }}
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -58,5 +58,6 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.branch_name }}
+          branch: "update-license-year"
+          branch-suffix: "${current_year}"
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 1 1 *"  # 毎年1月1日に実行
   workflow_dispatch:
+  push:
+    branches:
+      - "feature/refactor-update-license-workflow-5-20241027"
 
 jobs:
   commit-changes:

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: "0 0 1 1 *"  # 毎年1月1日に実行
   workflow_dispatch:
-  push:
-    branches:
-      - "feature/refactor-update-license-workflow-5-20241027"
 
 jobs:
   commit-changes:

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create new branch
         run: |
-          branch_name="update-license-year"
+          branch_name="update-license-year-${current_year}"
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 
@@ -60,5 +60,5 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "update-license-year"
+          branch: ${{ env.branch_name }}
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -5,13 +5,6 @@ on:
   schedule:
     - cron: "0 0 1 1 *"  # 毎年1月1日に実行
   workflow_dispatch:
-  push:
-    branches:
-      - "feature/refactor-update-license-workflow-5-20241027"
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   commit-changes:
@@ -51,7 +44,7 @@ jobs:
 
       - name: Push changes
         run: |
-          git push -u origin "$branch_name"
+          git push -fu origin "$branch_name"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -53,6 +53,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Ensure branch is pushed
+        run: |
+          git fetch origin
+          git branch -r
+
       - name: Wait for branch to be available
         run: sleep 5
 

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -22,26 +22,21 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Make changes (e.g., update LICENSE year)
         run: |
           current_year=$(date +"%Y")
           echo "current_year=$current_year" >> $GITHUB_ENV
+          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update LICENSE year
-        run: |
-          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
-
       - name: Create new branch
         run: |
-          branch_name="update-license-year-${current_year}"
+          branch_name="update-license-year-$current_year"
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 
@@ -49,28 +44,20 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git add LICENSE
-            git commit -m "Update License year to ${current_year}"
+            git commit -m "Update License year to $current_year"
           else
             echo "No changes to commit"
           fi
 
-      - name: Push changes to new branch
+      - name: Push changes
         run: |
-          git push -fu origin "$branch_name"
+          git push -u origin "$branch_name"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure branch is pushed
-        run: |
-          git fetch origin
-          git branch -r
-
-      - name: Wait for branch to be available
-        run: sleep 5
-
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.branch_name }}
-          base: "main"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          gh pr create --title "Update License year to $current_year" --body "This PR updates the license year to $current_year." --head "$branch_name" --base "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -30,16 +30,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create a new branch
+      - name: Create new branch
         run: |
-          branch_name="feature/update-license-year-$(date +'%Y%m%d-%H%M%S')"
+          branch_name="update-license-year-${current_year}"
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 
       - name: Commit changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git add LICENSE
-            git commit -m "Update License year to $current_year"
+            git commit -m "Update License year to ${current_year}"
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -21,12 +21,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Make changes (e.g., update LICENSE year)
-        run: |
-          current_year=$(date +"%Y")
-          echo "current_year=$current_year" >> $GITHUB_ENV
-          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
-
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
@@ -37,6 +31,12 @@ jobs:
           branch_name="update-license-year-${current_year}"
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
+
+      - name: Make changes (e.g., update LICENSE year)
+        run: |
+          current_year=$(date +"%Y")
+          echo "current_year=$current_year" >> $GITHUB_ENV
+          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -51,6 +51,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Wait for branch to be available
+        run: sleep 5
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -18,6 +18,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Make changes (e.g., update LICENSE year)
         run: |

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -59,5 +59,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "update-license-year"
-          branch-suffix: "${current_year}"
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -54,9 +54,5 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-<<<<<<< Updated upstream
           branch: $branch_name
-=======
-          branch: "${{ env.branch_name }}"
->>>>>>> Stashed changes
           base: "main"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -25,22 +25,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Make changes (e.g., update LICENSE year)
+        run: |
+          current_year=$(date +"%Y")
+          echo "current_year=$current_year" >> $GITHUB_ENV
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update LICENSE year
+        run: |
+          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Create new branch
         run: |
           branch_name="update-license-year-${current_year}"
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
-
-      - name: Make changes (e.g., update LICENSE year)
-        run: |
-          current_year=$(date +"%Y")
-          echo "current_year=$current_year" >> $GITHUB_ENV
-          sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create new branch
         run: |
-          branch_name="update-license-year-${current_year}"
+          branch_name="update-license-year"
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
 


### PR DESCRIPTION

## 📓 変更点の概要

- GitHubワークフローの設定を変更し、ライセンス年の更新に関するブランチ制限を解除しました。これにより、特定のブランチに依存せずにワークフローが実行されるようになりました。

## ⚒ 技術的な詳細や注意点

- 🛠️ **ブランチ制限の解除**: `.github/workflows/update-license-year.yml` から特定のブランチに対するプッシュイベントの制限を削除しました。これにより、ワークフローがより柔軟に実行されるようになります。
  
- 🔑 **GitHub App Tokenの生成**: ワークフロー内でGitHub App Tokenを生成するステップを追加しました。これにより、より安全にリポジトリへの変更をプッシュすることが可能になります。

- 🚀 **強制プッシュの設定**: 新しいブランチへの変更を強制的にプッシュするように設定を変更しました。これにより、既存のブランチに対する変更が確実に反映されるようになります。

- 📝 **ライセンス年の更新**: `LICENSE` ファイル内の年を自動的に更新するスクリプトを含めました。これにより、毎年のライセンス年の更新が自動化されます。

- ⚠️ **注意点**: ワークフローの変更により、GitHub Appの設定やシークレットの管理が必要となります。適切な権限とシークレットが設定されていることを確認してください。