### PR TITLE
## 🔧 pre-commitフックとGitHubワークフローの更新

### DIFF
--- a/.github/workflows/generate-pr.yml
+++ b/.github/workflows/generate-pr.yml
@@ -10,6 +10,7 @@ jobs:
   generate-pr-description:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event.pull_request.user.login != 'renovate'
     permissions:
       pull-requests: write
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v7
+    rev: v7.0.0
     hooks:
       - id: cspell
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.15.2
+    rev: v7
     hooks:
       - id: cspell
 

--- a/scripts/generate_pr_description.py
+++ b/scripts/generate_pr_description.py
@@ -19,7 +19,7 @@ def create_prompt(commit_logs):
 
     - 以下のコミットログとファイルの差分を読んで、理解し易いプルリクエストのタイトルと詳細な説明を日本語で作成してください。
     - Markdown 形式で記述してください。
-        - ただし出力内容の1行目は例外です。`# ` などは不要です。
+        - ただし出力内容の1行目は例外です。# などは不要です。
         - ファイル名はバッククオートで囲んでください。
         - https://github.com/orgs/community/discussions/16925 を参考にしてください。
             - 内容に応じて NOTE, TIPS, IMPORTANT, WARNING, CAUTION を使用してください。


### PR DESCRIPTION

## 📓 変更点の概要

- `streetsidesoftware/cspell-cli`のpre-commitフックのバージョンをv8.15.2からv7.0.0にダウングレードしました。
- GitHubワークフロー`generate-pr.yml`において、プルリクエスト作成手順のタイムアウトを10分に設定し、特定のユーザーによるイベントを除外する条件を追加しました。
- `generate_pr_description.py`のコメントを微修正しました。

## ⚒ 技術的な詳細や注意点

- 🔄 **pre-commitフックのバージョン変更**: 
  - `streetsidesoftware/cspell-cli`のバージョンをv8.15.2からv7.0.0に変更しました。これにより、特定のバージョンに固定され、予期しないバージョンアップによる影響を防ぎます。

- ⏱ **GitHubワークフローのタイムアウト設定**:
  - `generate-pr.yml`において、プルリクエスト作成手順のタイムアウトを10分に設定しました。これにより、長時間実行されるジョブを防ぎ、リソースの無駄を削減します。
  - `github.event.pull_request.user.login != 'renovate'`という条件を追加し、特定のユーザー（ここでは'renovate'）によるイベントを除外するようにしました。

- 📝 **コメントの微修正**:
  - `generate_pr_description.py`のコメントから不要なバッククオートを削除し、コードの可読性を向上させました。