### PR TITLE
🚀 GitHub Actionsのライセンス年更新ワークフローの改善

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Create new branch
         run: |
           branch_name="update-license-year-$current_year"
+          echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           git checkout -b "$branch_name"
 
       - name: Commit changes

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: write # required to commit changes
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -55,6 +55,10 @@ jobs:
             echo "changes_made=false" >> "$GITHUB_ENV"
           fi
 
+      - name: Push changes
+        if: env.changes_made == 'true'
+        run: git push -fu origin ${{ env.branch_name }}
+
       - name: Create Pull Request
         if: env.changes_made == 'true'
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -74,4 +74,4 @@ jobs:
           reviewers: "octocat"
           assignees: "octocat"
           draft: false
-          branch-suffix: timestamp
+          branch-suffix: "update-license-year-${{ env.current_year }}"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -75,4 +75,3 @@ jobs:
           reviewers: "octocat"
           assignees: "octocat"
           draft: false
-          branch-suffix: timestamp

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -74,4 +74,4 @@ jobs:
           reviewers: "octocat"
           assignees: "octocat"
           draft: false
-          branch-suffix: "update-license-year-${{ env.current_year }}"
+          branch-suffix: timestamp

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Push changes
         if: env.changes_made == 'true'
-        run: git push -fu origin ${{ env.branch_name }}
+        run: git push --set-upstream origin ${{ env.branch_name }}
 
       - name: Create Pull Request
         if: env.changes_made == 'true'

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add --bool push.autoSetupRemote true
 
       - name: Create new branch
         run: |
@@ -57,7 +58,7 @@ jobs:
 
       - name: Push changes
         if: env.changes_made == 'true'
-        run: git push --set-upstream origin ${{ env.branch_name }}
+        run: git push --set-upstream --force origin ${{ env.branch_name }}
 
       - name: Create Pull Request
         if: env.changes_made == 'true'

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config advice.refSyntax false
           git config --global --add --bool push.autoSetupRemote true
 
       - name: Create new branch

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write # required to commit changes
-      pull-requests: write
+      pull-requests: write # uses peter-evans/create-pull-request
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION

## 📒 変更点の概要

- `.github/workflows/update-license-year.yml` において、ライセンス年更新ワークフローの複数の改善を行いました。
- 新しいブランチ名を環境変数に設定する機能を追加しました。
- ブランチサフィックスの設定を削除し、現在の年に基づく形式に変更しました。
- プルリクエストの権限を明示的に指定しました。

## ⚒ 技術的な詳細

- **環境変数の設定**: 新しいブランチ名を `GITHUB_ENV` に設定することで、後続のステップでブランチ名を簡単に参照できるようにしました。
- **ブランチサフィックスの変更**: ブランチサフィックスをタイムスタンプから `update-license-year-${{ env.current_year }}` に変更し、後に削除しました。
- **Git設定の変更**: `git config advice.refSyntax false` を追加し、リファレンス構文に関するアドバイスを無効にしました。
- **権限の変更**: `contents` の権限を読み取りから書き込みに変更し、プルリクエストの権限を明示的に指定しました。
- **プッシュコマンドの修正**: `git push` コマンドを `--set-upstream --force` オプション付きで実行するように変更しました。

## ⚠ 注意点

- **強制プッシュの使用**: `git push --force` を使用しているため、既存のブランチの履歴が上書きされる可能性があります。使用には注意が必要です。
- **権限の変更**: 権限を変更したことで、リポジトリへの書き込みが可能になっています。適切なアクセス制御を行ってください。