### PR TITLE
🔧 GitHub Actionsワークフローからレビュアーとアサインを削除

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -70,6 +70,4 @@ jobs:
           branch: ${{ env.branch_name }}
           base: main
           labels: "auto-merge"
-          reviewers: "octocat"
-          assignees: "octocat"
           draft: false


### PR DESCRIPTION

## 📒 変更点の概要

- `.github/workflows/update-license-year.yml` ファイルにおいて、GitHub Actionsのライセンス年更新ワークフローからレビュアーとアサインの指定を削除しました。

## ⚒ 技術的な詳細

- `reviewers` と `assignees` の指定を削除することで、プルリクエスト作成時に自動で特定のユーザーがレビュアーやアサインに設定されなくなります。
- この変更により、プルリクエストのレビュープロセスが柔軟になり、特定のユーザーに依存しない運用が可能になります。

## ⚠ 注意点

- この変更により、レビュアーやアサインが手動で設定される必要があります。レビュープロセスの流れが変わる可能性があるため、チーム内での確認と調整が必要です。