### PR TITLE
🚀 GitHub Actionsのライセンス年更新ワークフローの改善

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -8,6 +8,7 @@
 	tool = code --wait \"$MERGED\"
 [push]
 	default = simple
+	autoSetupRemote = true
 [diff]
 	tool = default-difftool
 [difftool "default-difftool"]

--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
-    if: contains(github.event.pull_request.user.login, 'renovate') == false
+    if: contains('["renovate", "tqer39-apps"]', github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Make changes (e.g., update LICENSE year)
         run: |
           current_year=$(date +"%Y")
+          echo "current_year=$current_year" >> "$GITHUB_ENV"
           sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Configure Git

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create new branch
         run: |
-          branch_name="update-license-year-$current_year"
+          echo "branch_name=update-license-year-$current_year" >> "$GITHUB_ENV"
           git checkout -b "$branch_name"
 
       - name: Commit changes

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Create new branch
         run: |
-          echo "branch_name=update-license-year-$current_year" >> "$GITHUB_ENV"
+          branch_name="update-license-year-$current_year"
+          echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           git checkout -b "$branch_name"
 
       - name: Commit changes

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -13,6 +13,8 @@ jobs:
   commit-changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write # git push するために必要
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -5,14 +5,14 @@ on:
   schedule:
     - cron: "0 0 1 1 *"  # 毎年1月1日に実行
   workflow_dispatch:
+  push:
+    branches:
+      - "feature/**"
 
 jobs:
   commit-changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write # required to commit changes
-      pull-requests: write # uses peter-evans/create-pull-request
     steps:
       - uses: actions/checkout@v4
 
@@ -27,47 +27,36 @@ jobs:
       - name: Make changes (e.g., update LICENSE year)
         run: |
           current_year=$(date +"%Y")
-          echo "current_year=$current_year" >> $GITHUB_ENV
           sed -i "s/[0-9]\{4\}/$current_year/g" LICENSE
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config advice.refSyntax false
-          git config --global --add --bool push.autoSetupRemote true
 
       - name: Create new branch
         run: |
           branch_name="update-license-year-$current_year"
-          echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           git checkout -b "$branch_name"
 
       - name: Commit changes
-        id: commit_changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git add LICENSE
             git commit -m "Update License year to $current_year"
-            echo "changes_made=true" >> "$GITHUB_ENV"
           else
             echo "No changes to commit"
-            echo "changes_made=false" >> "$GITHUB_ENV"
           fi
 
       - name: Push changes
-        if: env.changes_made == 'true'
-        run: git push --set-upstream --force origin ${{ env.branch_name }}
+        run: |
+          git push -fu origin "$branch_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        if: env.changes_made == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update License year to $current_year"
-          title: "Update License year to $current_year"
-          body: "This PR updates the LICENSE year to $current_year."
-          branch: ${{ env.branch_name }}
-          base: main
-          labels: "auto-merge"
-          draft: false
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          gh auth setup-git
+          gh pr create --title "Update License year to $current_year" --body "This PR updates the license year to $current_year." --head "$branch_name" --base "main"


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actionsのワークフローで、ライセンス年を更新する際のブランチ名の設定方法を改善しました。
- プッシュイベントをトリガーとして追加し、特定のブランチパターンでの変更を検知するようにしました。
- `.gitconfig`に`autoSetupRemote`オプションを追加しました。

## ⚒ 技術的な詳細

- **ブランチ名の設定方法の改善**:
  - ブランチ名を直接環境変数に設定する方法から、一度変数に格納してから環境変数に設定する方法に変更しました。これにより、コードの可読性が向上しました。
  
- **GitHub Actionsの権限設定**:
  - ワークフローに書き込み権限を追加し、`git push`を行うための設定を行いました。

- **プッシュイベントの追加**:
  - `feature/**`パターンのブランチに対するプッシュイベントをトリガーとして追加しました。これにより、特定のブランチに対する変更を自動的に検知し、ワークフローを実行できます。

- **`.gitconfig`の更新**:
  - `autoSetupRemote`オプションを追加し、リモートリポジトリの設定を自動化しました。これにより、ブランチ作成時にリモートの設定が自動的に行われるようになります。

## ⚠ 注意点

- **GitHub Actionsのトークン設定**:
  - プルリクエストの作成にはGitHub CLIを使用しており、`GITHUB_TOKEN`の設定が必要です。環境変数として適切に設定されていることを確認してください。