### PR TITLE
🔧 GitHub ActionsのPR説明生成ワークフローのユーザー条件チェックの修正

### DIFF
--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
     # Check if the PR is not created by 'renovate' or 'tqer39-apps'
-    if: github.event.pull_request.user.login != 'renovate' && github.event.pull_request.user.login != 'tqer39-apps'
+    if: contains(fromJSON('["renovate", "tqer39-apps"]'), github.event.pull_request.user.login)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
     # Check if the PR is not created by 'renovate' or 'tqer39-apps'
-    if: contains(fromJSON('["renovate", "tqer39-apps"]'), github.event.pull_request.user.login)
+    if: contains(fromJSON('["renovate", "tqer39-apps"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub ActionsのPR説明生成ワークフローにおいて、PRが特定のユーザー（`renovate`や`tqer39-apps`）によって作成された場合に処理をスキップする条件の論理を修正しました。

## ⚒ 技術的な詳細

- `.github/workflows/generate-pr-description.yml`ファイルの`if`条件を修正しました。
  - 以前の条件では、`github.event.pull_request.user.login`が`renovate`または`tqer39-apps`でない場合に処理を行うようになっていました。
  - 修正後は、`fromJSON`関数を使用して、ユーザー名がリストに含まれているかどうかを`contains`関数でチェックし、その結果が`false`の場合に処理を行うように変更しました。

## ⚠ 注意点

- この修正により、PRが`renovate`や`tqer39-apps`によって作成された場合は、PR説明生成の処理がスキップされるようになります。これにより、不要なPR説明の生成を防ぐことができます。