### PR TITLE
🔧 PR作成者チェックの条件を更新し、'[bot]'を除外リストに追加

### DIFF
--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
-    # Check if the PR is not created by 'renovate' or 'tqer39-apps'
-    if: contains(fromJSON('["renovate", "tqer39-apps"]'), github.event.pull_request.user.login) == false
+    # Check if the PR is not created by '[bot]' or 'renovate'
+    if: contains(fromJSON('["[bot]", "renovate"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actions のワークフローファイルである`generate-pr-description.yml`が更新されました。
- プルリクエスト作成者のチェック条件が変更され、`[bot]`が除外リストに追加されました。

## ⚒ 技術的な詳細

- `generate-pr-description.yml`内の条件式が以下のように変更されました。
  - 変更前: `contains(fromJSON('["renovate", "tqer39-apps"]'), github.event.pull_request.user.login) == false`
  - 変更後: `contains(fromJSON('["[bot]", "renovate"]'), github.event.pull_request.user.login) == false`
- この変更により、プルリクエストが`[bot]`または`renovate`によって作成された場合、ワークフローが実行されないようになります。

## ⚠ 注意点

- `[bot]`が除外リストに追加されたため、他のボットアカウントがプルリクエストを作成した場合もワークフローが実行されない可能性があります。必要に応じて除外リストを調整してください。