### PR TITLE
🔧 GitHub ActionsのPR作成者チェック条件を更新

### DIFF
--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
-    # Check if the PR is not created by '[bot]' or 'renovate'
-    if: contains(fromJSON('["[bot]", "renovate"]'), github.event.pull_request.user.login) == false
+    # Check if the PR is not created by 'renovate' or 'tqer39-apps'
+    if: contains(fromJSON('["renovate[bot]", "tqer39-apps[bot]"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actionsのワークフローファイル`generate-pr-description.yml`において、PR作成者のチェック条件を更新しました。
- 'tqer39-apps[bot]'を除外リストに追加し、PRがこのユーザーによって作成された場合にアクションが実行されないようにしました。

## ⚒ 技術的な詳細

- `generate-pr-description.yml`の条件文を以下のように変更しました:
  ```yaml
  if: contains(fromJSON('["renovate[bot]", "tqer39-apps[bot]"]'), github.event.pull_request.user.login) == false
  ```
  - これにより、PRが'renovate[bot]'または'tqer39-apps[bot]'によって作成された場合、アクションが実行されないようになります。

## ⚠ 注意点

- この変更により、'tqer39-apps[bot]'が作成したPRに対しては自動的にPR説明が生成されなくなります。必要に応じて手動で説明を追加してください。