### PR TITLE
🔄 GitHub Actionsのワークフローを改善し、openai-generate-pr-descriptionアクションをアップデート

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   add-reviews:
     permissions:

--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tqer39/openai-generate-pr-description@v1.0.2
+      - uses: tqer39/openai-generate-pr-description@v1.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -9,6 +9,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   generate-pr-description:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   auto-labeling:

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -17,6 +17,10 @@ on:
       - 'setup'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 env:
   DL_PATH: "$HOME/Downloads"
   HACKGEN_VERSION: "2.9.0"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 1 1 *' # 毎年1月1日に実行
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   commit-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## 📒 変更点の概要

- `generate-pr-description.yml` の `openai-generate-pr-description` アクションをバージョン v1.0.2 から v1.0.3 にアップデートしました。
- 複数のワークフローに同時実行制御を追加し、進行中のジョブをキャンセルする設定を適用しました。

## ⚒ 技術的な詳細

- `generate-pr-description.yml`:
  - `tqer39/openai-generate-pr-description` アクションのバージョンを v1.0.3 に更新しました。これにより、最新の機能やバグ修正が反映されます。
  - `concurrency` セクションを追加し、同時実行制御を設定しました。これにより、同じワークフローが同時に実行されることを防ぎ、進行中のジョブをキャンセルします。

- 他のワークフロー (`auto-assign.yml`, `labeler.yml`, `test-setup.yml`, `update-license-year.yml`) にも同様の `concurrency` 設定を追加しました。

## ⚠ 注意点

- 同時実行制御の設定により、同じワークフローが同時に実行されることがなくなりますが、必要に応じて設定を調整することを検討してください。