### PR TITLE
🔧 Add PowerShell script to set execution policy to RemoteSigned

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,15 @@
+$executionPolicies = Get-ExecutionPolicy -List
+
+if ($executionPolicies.Process -ne 'RemoteSigned') {
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force
+}
+
+if ($executionPolicies.CurrentUser -ne 'RemoteSigned') {
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+}
+
+Get-ExecutionPolicy -List
+
+exit 0
+
+# Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression


### PR DESCRIPTION

## 📒 変更点の概要

- 新しいPowerShellスクリプト`setup.ps1`が追加されました。このスクリプトは、PowerShellの実行ポリシーを`RemoteSigned`に設定します。

## ⚒ 技術的な詳細

- スクリプトは、現在の実行ポリシーを取得し、`Process`および`CurrentUser`スコープのポリシーが`RemoteSigned`でない場合に、それぞれのスコープでポリシーを`RemoteSigned`に設定します。
- `Get-ExecutionPolicy -List`コマンドを使用して、すべてのスコープの実行ポリシーを確認します。
- スクリプトの最後に`exit 0`があり、正常終了を示します。
- コメントアウトされた行として、Scoopのインストールを行うコマンドが含まれていますが、現時点では実行されません。

## ⚠ 注意点

- 💡 スクリプトは`-Force`オプションを使用しているため、ユーザーの確認なしに実行ポリシーを変更します。実行環境での影響を確認した上で使用してください。
- 💡 `RemoteSigned`ポリシーは、リモートからダウンロードされたスクリプトの署名を要求します。セキュリティ上の理由から、スクリプトの実行には注意が必要です。